### PR TITLE
Address misplacement of Learn nav footer

### DIFF
--- a/tryapl/index.html
+++ b/tryapl/index.html
@@ -96,7 +96,7 @@
         <br><br>
         In either case, concepts that take several lines of code in other languages can often be reduced to a few characters in APL. You'll quickly find that APL's symbols are organized in a logical, mnemonic manner that makes it easy to express advanced concepts clearly and concisely, and makes it easy to learn too. Move to the <a href="#" onclick="$('#learnTab').click()">Learn</a> tab and get started!
       </div>
-      <div class="content grid" id="learn">
+      <div class="content grid" id="learn" data-in_notebook="no">
         <div id="loadnb">
           <h1>Interactive lessons</h1>
           TryAPL uses the Jupyter Notebook format to provide interactive lessons. Use one of the listed, or bring your own. Most documents based on the <a target="_blank" href="https://github.com/Dyalog/dyalog-jupyter-kernel">Dyalog Jupyter Kernel</a> work fine here.

--- a/tryapl/lib/tiolb.js
+++ b/tryapl/lib/tiolb.js
@@ -58,9 +58,27 @@ let ff=x=>{
   if(nn!=='textarea'&&(nn!=='input'||t0.type!=='text'&&t0.type!=='search'))return
   t=t0;if(!t.ngn){t.ngn=1;ts.push(t);ev(t,'keydown',fk)}
 }
-let upd=_=>{d.body.style.marginTop=lb.clientHeight+'px';
-                               session.style.height="calc(100vh - 8px - " + lb.clientHeight+'px)';
-$$(".content").forEach(fn=node=>{node.style.height="calc(100vh - 3em - 2px - " + lb.clientHeight+'px)';});
+let upd=_=>{
+  d.body.style.marginTop=lb.clientHeight+'px';
+  session.style.height="calc(100vh - 8px - " + lb.clientHeight+'px)';
+  $$(".content").forEach(fn=node=>{
+    if(node.id === "learn") {
+      let inNotebook = node.getAttribute("data-in_notebook");
+      switch(inNotebook) {
+        case "yes":
+          node.style.height="calc(100vh - 2px - " + lb.clientHeight+'px)';
+          break;
+        case "no":
+          node.style.height="calc(100vh - 3em - 2px - " + lb.clientHeight+'px)';
+          break;
+        default:
+          console.error(`Error: expected "yes" or "no", got: ${inNotebook}`);
+          break;
+      }
+    } else {
+      node.style.height="calc(100vh - 3em - 2px - " + lb.clientHeight+'px)';
+    }
+  });
 }
 upd();ev(window,'resize',upd)
 ev(d,'focus',ff,!0);let ae=d.activeElement;ae&&ff({type:'focus',target:ae})

--- a/tryapl/script.js
+++ b/tryapl/script.js
@@ -115,6 +115,7 @@ nbFill=t=>{
 }
 
 nbLoad=id=> {
+  $("#learn").setAttribute("data-in_notebook", "yes");
   let lb_height = document.getElementsByClassName("ngn_lb")[0].clientHeight;
   $("#learn").style.height=`calc(100vh - 2px - ${lb_height}px)`;
   url = $(id).value;
@@ -247,6 +248,7 @@ nbReload=_=>{
 
 nbClose=_=>{
   log("close");
+  $("#learn").setAttribute("data-in_notebook", "no");
   learnButtons.classList.add("hidden");
   loadnb.classList.remove("hidden");
   mdrender.style.display = "none";


### PR DESCRIPTION
Previous pull request (#15) solved scrollbar overflow issue, but reintroduced nav alignment problems by neglectfully adjusting code in [lib/tiolb.js](../tree/master/tryapl/lib/tiolb.js) as [mentioned by Adam](https://github.com/rikedyp/APLProblemSets/pull/15#issuecomment-648116788).

This commit adds an HTML attribute to the Learn tab which tracks whether the user is in the Markdown renderer. The `upd` function is modified to check for the presence of this attribute and adjust the div accordingly.